### PR TITLE
Addressing bug #4

### DIFF
--- a/pkg/R/unimodularity.R
+++ b/pkg/R/unimodularity.R
@@ -32,7 +32,7 @@ is_totally_unimodular <- function(A) {
     
     # A matrix with elements not in {-1,0,1} cannot be totally unimodular.
     if ( !all(A %in% c(-1,0,1)) ){
-        value <- FALSE
+        return(FALSE)
     }
 
     # After reduction, A has no rows or columns containing less than 2 elements.
@@ -116,7 +116,7 @@ hellerTompkins <- function(A){
         for ( i in 1:ncol(I)){
             M1 <- A[I[ , i], ,drop=FALSE]
             M2 <- A[-I[ , i], ,drop=FALSE]
-            if ( !any(abs(colSums(M1)) == 2) && !any(abs(colSums(M2)) == 2) ){
+            if ( !any(abs(rowSums(M1)) == 2) && !any(abs(rowSums(M2)) == 2) ){
                 return(TRUE)
             }
         }


### PR DESCRIPTION
Escape further checks if matrix entries are not all in the set {-1,0,1}, and apply rowSum instead of colSum within Heller-Tompkins check.
There may be other issues in the function that need more comprehensive testing, but I've tested this on a few cases that gave incorrect results before:

is_totally_unimodular(diag(2,1))
is_totally_unimodular(matrix(c(1,1,1,-1),nrow=2))
is_totally_unimodular(matrix(c(0,1,1,1,0,1,1,1,0), nrow=3))
is_totally_unimodular(matrix(c(1,1,0,0,1,0,1,0,1,0,0,1,1,1,1,1), nrow=4))